### PR TITLE
Update AppLogger to 1.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/thatfactory/applogger",
-            from: "0.1.0"
+            from: "1.0.0"
         ),
         .package(
             url: "https://github.com/apple/swift-testing.git",


### PR DESCRIPTION
## Summary
- update the `AppLogger` dependency from `0.1.0` to `1.0.0`
- align the package with the new `AppLogLevel`-based `AppLogger` API line

## Testing
- `swift test`